### PR TITLE
hide immutables from the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ will be set to the default values.
 ```java
 public static final class ExampleApplication extends Application<ExampleConfiguration> {
 
-    private final WebSecurityConfiguration webSecurityDefaults = new WebSecurityConfiguration.Builder()
+    private final WebSecurityConfiguration webSecurityDefaults = WebSecurityConfiguration.builder()
 
             // set app defaults for different header values
             .contentSecurityPolicy(CSP_FROM_APP)
@@ -84,7 +84,7 @@ public static final class ExampleApplication extends Application<ExampleConfigur
 
             // CORS is still DISABLED, since the allowedOrigins is not set, but the default value will be
             // respected if it's ever turned on
-            .cors(new CorsConfiguration.Builder()
+            .cors(CorsConfiguration.builder()
                     .preflightMaxAge(60 * 10)
                     .build())
 

--- a/src/main/java/com/palantir/websecurity/CorsConfiguration.java
+++ b/src/main/java/com/palantir/websecurity/CorsConfiguration.java
@@ -127,14 +127,35 @@ public abstract class CorsConfiguration {
     /**
      * Provides a configuration with default values.
      */
-    public static final CorsConfiguration DEFAULT = new CorsConfiguration.Builder().build();
+    public static final CorsConfiguration DEFAULT = CorsConfiguration.builder().build();
 
     /**
      * Provides a configuration that is disabled.
      */
-    public static final CorsConfiguration DISABLED = new CorsConfiguration.Builder()
+    public static final CorsConfiguration DISABLED = CorsConfiguration.builder()
             .allowedOrigins(DISABLED_ORIGINS)
             .build();
 
-    public static class Builder extends ImmutableCorsConfiguration.Builder {}
+    // hides implementation details
+    public static Builder builder() {
+        return ImmutableCorsConfiguration.builder();
+    }
+
+    // hides implementation details
+    public interface Builder {
+
+        Builder allowCredentials(boolean allowCredentials);
+
+        Builder allowedHeaders(String allowedHeaders);
+
+        Builder allowedMethods(String allowedMethods);
+
+        Builder allowedOrigins(String allowedOrigins);
+
+        Builder exposedHeaders(String exposedHeaders);
+
+        Builder preflightMaxAge(long preflightMaxAge);
+
+        CorsConfiguration build();
+    }
 }

--- a/src/main/java/com/palantir/websecurity/WebSecurityBundle.java
+++ b/src/main/java/com/palantir/websecurity/WebSecurityBundle.java
@@ -49,7 +49,7 @@ public final class WebSecurityBundle implements ConfiguredBundle<WebSecurityConf
      * Constructs a bundle with the out of the box defaults.
      */
     public WebSecurityBundle() {
-        this(new WebSecurityConfiguration.Builder().build());
+        this(WebSecurityConfiguration.builder().build());
     }
 
     /**
@@ -70,7 +70,7 @@ public final class WebSecurityBundle implements ConfiguredBundle<WebSecurityConf
         checkNotNull(configuration);
         checkNotNull(environment);
 
-        WebSecurityConfiguration.Builder builder = new WebSecurityConfiguration.Builder();
+        WebSecurityConfiguration.Builder builder = WebSecurityConfiguration.builder();
         builder.from(applicationDefaults);
 
         if (configuration.getWebSecurityConfiguration().isPresent()) {

--- a/src/main/java/com/palantir/websecurity/WebSecurityConfiguration.java
+++ b/src/main/java/com/palantir/websecurity/WebSecurityConfiguration.java
@@ -43,5 +43,31 @@ public abstract class WebSecurityConfiguration {
      */
     public abstract Optional<CorsConfiguration> cors();
 
-    public static class Builder extends ImmutableWebSecurityConfiguration.Builder {}
+    /**
+     * Provides a configuration with default values.
+     */
+    public static final WebSecurityConfiguration DEFAULT = WebSecurityConfiguration.builder().build();
+
+    // hides implementation details
+    public static Builder builder() {
+        return ImmutableWebSecurityConfiguration.builder();
+    }
+
+    // hides implementation details
+    public interface Builder {
+
+        Builder contentSecurityPolicy(String contentSecurityPolicy);
+
+        Builder contentTypeOptions(String contentTypeOptions);
+
+        Builder frameOptions(String frameOptions);
+
+        Builder xssProtection(String xssProtection);
+
+        Builder cors(CorsConfiguration corsConfiguration);
+
+        Builder from(WebSecurityConfiguration otherConfig);
+
+        WebSecurityConfiguration build();
+    }
 }

--- a/src/test/java/com/palantir/websecurity/CorsConfigurationTests.java
+++ b/src/test/java/com/palantir/websecurity/CorsConfigurationTests.java
@@ -29,7 +29,7 @@ public final class CorsConfigurationTests {
 
     @Test
     public void testAllowedOrigins_allowStar() {
-        CorsConfiguration config = new CorsConfiguration.Builder().allowedOrigins("*").build();
+        CorsConfiguration config = CorsConfiguration.builder().allowedOrigins("*").build();
 
         Set<ConstraintViolation<CorsConfiguration>> violations = VALIDATOR.validate(config);
         assertTrue(violations.isEmpty());
@@ -37,7 +37,7 @@ public final class CorsConfigurationTests {
 
     @Test
     public void testAllowedOrigins_invalidUrl() {
-        CorsConfiguration config = new CorsConfiguration.Builder()
+        CorsConfiguration config = CorsConfiguration.builder()
                 .allowedOrigins("http://good.url,:/123/this/is/not/a.valid.url")
                 .build();
 
@@ -47,7 +47,7 @@ public final class CorsConfigurationTests {
 
     @Test
     public void testAllowedOrigins_urlCannotHavePath() {
-        CorsConfiguration config = new CorsConfiguration.Builder()
+        CorsConfiguration config = CorsConfiguration.builder()
                 .allowedOrigins("http://good.url,http://url.with.path/")
                 .build();
 
@@ -57,7 +57,7 @@ public final class CorsConfigurationTests {
 
     @Test
     public void testAllowedOrigins_validRegex() {
-        CorsConfiguration config = new CorsConfiguration.Builder()
+        CorsConfiguration config = CorsConfiguration.builder()
                 .allowedOrigins("http://*(dfdfd).$")
                 .build();
 
@@ -67,7 +67,7 @@ public final class CorsConfigurationTests {
 
     @Test
     public void testAllowedOrigins_invalidRegex() {
-        CorsConfiguration config = new CorsConfiguration.Builder()
+        CorsConfiguration config = CorsConfiguration.builder()
                 .allowedOrigins("http://*(dfdfd")
                 .build();
 
@@ -77,7 +77,7 @@ public final class CorsConfigurationTests {
 
     @Test
     public void testPreflightMaxAge_cannotBeNegative() {
-        CorsConfiguration config = new CorsConfiguration.Builder()
+        CorsConfiguration config = CorsConfiguration.builder()
                 .preflightMaxAge(-1L)
                 .build();
 

--- a/src/test/java/com/palantir/websecurity/WebSecurityBundleTests.java
+++ b/src/test/java/com/palantir/websecurity/WebSecurityBundleTests.java
@@ -36,7 +36,7 @@ public final class WebSecurityBundleTests {
     @Test
     public void testDefaultFiltersApplied() throws Exception {
         WebSecurityBundle bundle = new WebSecurityBundle();
-        WebSecurityConfiguration webSecurityConfig = new WebSecurityConfiguration.Builder().build();
+        WebSecurityConfiguration webSecurityConfig = WebSecurityConfiguration.DEFAULT;
 
         when(this.appConfig.getWebSecurityConfiguration()).thenReturn(Optional.of(webSecurityConfig));
 
@@ -48,8 +48,8 @@ public final class WebSecurityBundleTests {
     @Test
     public void testFiltersAppliedWhenEnabled() throws Exception {
         WebSecurityBundle bundle = new WebSecurityBundle();
-        WebSecurityConfiguration webSecurityConfig = new WebSecurityConfiguration.Builder()
-                .cors(new CorsConfiguration.Builder().allowedOrigins("http://origin").build())
+        WebSecurityConfiguration webSecurityConfig = WebSecurityConfiguration.builder()
+                .cors(CorsConfiguration.builder().allowedOrigins("http://origin").build())
                 .build();
 
         when(this.appConfig.getWebSecurityConfiguration()).thenReturn(Optional.of(webSecurityConfig));
@@ -62,7 +62,7 @@ public final class WebSecurityBundleTests {
     @Test
     public void testFiltersNotAppliedWhenDisabled() throws Exception {
         WebSecurityBundle bundle = new WebSecurityBundle();
-        WebSecurityConfiguration webSecurityConfig = new WebSecurityConfiguration.Builder()
+        WebSecurityConfiguration webSecurityConfig = WebSecurityConfiguration.builder()
                 .cors(CorsConfiguration.DISABLED)
                 .build();
 
@@ -75,10 +75,10 @@ public final class WebSecurityBundleTests {
 
     @Test
     public void testYamlOverridesAppDefaults() throws Exception {
-        WebSecurityConfiguration appDefaultConfig = new WebSecurityConfiguration.Builder()
-                .cors(new CorsConfiguration.Builder().allowedOrigins("http://origin").build())
+        WebSecurityConfiguration appDefaultConfig = WebSecurityConfiguration.builder()
+                .cors(CorsConfiguration.builder().allowedOrigins("http://origin").build())
                 .build();
-        WebSecurityConfiguration yamlConfig = new WebSecurityConfiguration.Builder()
+        WebSecurityConfiguration yamlConfig = WebSecurityConfiguration.builder()
                 .cors(CorsConfiguration.DISABLED)
                 .build();
         WebSecurityBundle bundle = new WebSecurityBundle(appDefaultConfig);
@@ -93,8 +93,8 @@ public final class WebSecurityBundleTests {
     @Test
     @SuppressWarnings("unchecked")
     public void testDefaultPropertyMap() throws Exception {
-        WebSecurityConfiguration appDefaultConfig = new WebSecurityConfiguration.Builder()
-                .cors(new CorsConfiguration.Builder()
+        WebSecurityConfiguration appDefaultConfig = WebSecurityConfiguration.builder()
+                .cors(CorsConfiguration.builder()
                         .allowedOrigins("http://origin")
                         .build())
                 .build();
@@ -122,7 +122,7 @@ public final class WebSecurityBundleTests {
     @Test
     @SuppressWarnings("unchecked")
     public void testPropertyMapAddsAll() throws Exception {
-        CorsConfiguration config = new CorsConfiguration.Builder()
+        CorsConfiguration config = CorsConfiguration.builder()
                 .allowedOrigins("origins")
                 .allowedMethods("methods")
                 .allowedHeaders("headers")
@@ -130,7 +130,7 @@ public final class WebSecurityBundleTests {
                 .allowCredentials(true)
                 .exposedHeaders("exposed")
                 .build();
-        WebSecurityConfiguration appDefaultConfig = new WebSecurityConfiguration.Builder()
+        WebSecurityConfiguration appDefaultConfig = WebSecurityConfiguration.builder()
                 .cors(config)
                 .build();
         WebSecurityBundle bundle = new WebSecurityBundle(appDefaultConfig);

--- a/src/test/java/com/palantir/websecurity/filters/WebSecurityFilterTests.java
+++ b/src/test/java/com/palantir/websecurity/filters/WebSecurityFilterTests.java
@@ -22,7 +22,8 @@ import org.springframework.mock.web.MockHttpServletResponse;
  */
 public final class WebSecurityFilterTests {
 
-    private final WebSecurityConfiguration config = new WebSecurityConfiguration.Builder().build();
+    private static final WebSecurityConfiguration DEFAULT_CONFIG = WebSecurityConfiguration.DEFAULT;
+
     private final MockHttpServletResponse response = new MockHttpServletResponse();
     private final FilterChain chain = mock(FilterChain.class);
 
@@ -30,7 +31,7 @@ public final class WebSecurityFilterTests {
     public void testInjectInHttpServletRequests() throws IOException, ServletException {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/index.html");
 
-        WebSecurityFilter filter = new WebSecurityFilter(this.config, "/jersey/root/*");
+        WebSecurityFilter filter = new WebSecurityFilter(DEFAULT_CONFIG, "/jersey/root/*");
         request.setPathInfo("/api");
 
         filter.doFilter(request, response, chain);
@@ -41,19 +42,19 @@ public final class WebSecurityFilterTests {
 
     @Test
     public void testNotInjectForJerseyPathWithStar() throws IOException, ServletException {
-        WebSecurityFilter filter = new WebSecurityFilter(this.config, "/api/*");
+        WebSecurityFilter filter = new WebSecurityFilter(DEFAULT_CONFIG, "/api/*");
         assertNotInjecting(filter);
     }
 
     @Test
     public void testNotInjectForJerseyPathNoStar() throws IOException, ServletException {
-        WebSecurityFilter filter = new WebSecurityFilter(this.config, "/api/");
+        WebSecurityFilter filter = new WebSecurityFilter(DEFAULT_CONFIG, "/api/");
         assertNotInjecting(filter);
     }
 
     @Test
     public void testNotInjectForJerseyPathNoSlash() throws IOException, ServletException {
-        WebSecurityFilter filter = new WebSecurityFilter(this.config, "/api");
+        WebSecurityFilter filter = new WebSecurityFilter(DEFAULT_CONFIG, "/api");
         assertNotInjecting(filter);
     }
 

--- a/src/test/java/com/palantir/websecurity/filters/WebSecurityHeaderInjectorTests.java
+++ b/src/test/java/com/palantir/websecurity/filters/WebSecurityHeaderInjectorTests.java
@@ -26,7 +26,7 @@ public final class WebSecurityHeaderInjectorTests {
 
     @Test
     public void testDisabledNoHeaders() {
-        WebSecurityHeaderInjector injector = new WebSecurityHeaderInjector(new WebSecurityConfiguration.Builder()
+        WebSecurityHeaderInjector injector = new WebSecurityHeaderInjector(WebSecurityConfiguration.builder()
                 .contentSecurityPolicy(WebSecurityConfiguration.TURN_OFF)
                 .contentTypeOptions(WebSecurityConfiguration.TURN_OFF)
                 .frameOptions(WebSecurityConfiguration.TURN_OFF)
@@ -44,7 +44,7 @@ public final class WebSecurityHeaderInjectorTests {
 
     @Test
     public void testHeadersReplacedNotAppended() {
-        WebSecurityConfiguration config = new WebSecurityConfiguration.Builder().build();
+        WebSecurityConfiguration config = WebSecurityConfiguration.DEFAULT;
         WebSecurityHeaderInjector injector = new WebSecurityHeaderInjector(config);
 
         request.addHeader(HttpHeaders.USER_AGENT, WebSecurityHeaderInjector.USER_AGENT_IE_10);
@@ -66,7 +66,7 @@ public final class WebSecurityHeaderInjectorTests {
 
     @Test
     public void testContentSecurityPolicyNonIe10or11() {
-        WebSecurityHeaderInjector injector = new WebSecurityHeaderInjector(new WebSecurityConfiguration.Builder()
+        WebSecurityHeaderInjector injector = new WebSecurityHeaderInjector(WebSecurityConfiguration.builder()
                 .contentSecurityPolicy(TEST_VALUE)
                 .build());
 
@@ -80,7 +80,7 @@ public final class WebSecurityHeaderInjectorTests {
 
     @Test
     public void testContentSecurityPolicyIe10() {
-        WebSecurityHeaderInjector injector = new WebSecurityHeaderInjector(new WebSecurityConfiguration.Builder()
+        WebSecurityHeaderInjector injector = new WebSecurityHeaderInjector(WebSecurityConfiguration.builder()
                 .contentSecurityPolicy(TEST_VALUE)
                 .build());
 
@@ -94,7 +94,7 @@ public final class WebSecurityHeaderInjectorTests {
 
     @Test
     public void testContentSecurityPolicyIe11() {
-        WebSecurityHeaderInjector injector = new WebSecurityHeaderInjector(new WebSecurityConfiguration.Builder()
+        WebSecurityHeaderInjector injector = new WebSecurityHeaderInjector(WebSecurityConfiguration.builder()
                 .contentSecurityPolicy(TEST_VALUE)
                 .build());
 
@@ -108,7 +108,7 @@ public final class WebSecurityHeaderInjectorTests {
 
     @Test
     public void testContentTypeOptions() {
-        WebSecurityHeaderInjector injector = new WebSecurityHeaderInjector(new WebSecurityConfiguration.Builder()
+        WebSecurityHeaderInjector injector = new WebSecurityHeaderInjector(WebSecurityConfiguration.builder()
                 .contentTypeOptions(TEST_VALUE)
                 .build());
 
@@ -119,7 +119,7 @@ public final class WebSecurityHeaderInjectorTests {
 
     @Test
     public void testFrameOptions() {
-        WebSecurityHeaderInjector injector = new WebSecurityHeaderInjector(new WebSecurityConfiguration.Builder()
+        WebSecurityHeaderInjector injector = new WebSecurityHeaderInjector(WebSecurityConfiguration.builder()
                 .frameOptions(TEST_VALUE)
                 .build());
 
@@ -130,7 +130,7 @@ public final class WebSecurityHeaderInjectorTests {
 
     @Test
     public void testXssProtection() {
-        WebSecurityHeaderInjector injector = new WebSecurityHeaderInjector(new WebSecurityConfiguration.Builder()
+        WebSecurityHeaderInjector injector = new WebSecurityHeaderInjector(WebSecurityConfiguration.builder()
                 .xssProtection(TEST_VALUE)
                 .build());
 

--- a/src/test/java/example/Example.java
+++ b/src/test/java/example/Example.java
@@ -65,7 +65,7 @@ public final class Example {
 
     public static final class ExampleApplication extends Application<ExampleConfiguration> {
 
-        private final WebSecurityConfiguration webSecurityDefaults = new WebSecurityConfiguration.Builder()
+        private final WebSecurityConfiguration webSecurityDefaults = WebSecurityConfiguration.builder()
 
                 // set app defaults for different header values
                 .contentSecurityPolicy(CSP_FROM_APP)
@@ -73,7 +73,7 @@ public final class Example {
 
                 // CORS is still DISABLED, since the allowedOrigins is not set, but the default value will be
                 // respected if it's ever turned on
-                .cors(new CorsConfiguration.Builder()
+                .cors(CorsConfiguration.builder()
                         .preflightMaxAge(60 * 10)
                         .build())
                 .build();


### PR DESCRIPTION
the immutables library ends up being exposed through the API if you do not define the Builder interface for a specific class. this means you are requiring consuming applications to include the library or they'll throw an exception at build time.

the solution is to hide the implementation class using the pattern described in the immutables docs here: http://immutables.github.io/immutable.html#hide-implementation-class
