### PR TITLE
add more granular filters

### DIFF
--- a/src/main/java/com/palantir/websecurity/WebSecurityBundle.java
+++ b/src/main/java/com/palantir/websecurity/WebSecurityBundle.java
@@ -8,7 +8,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.collect.ImmutableMap;
-import com.palantir.websecurity.filters.WebSecurityFilter;
+import com.palantir.websecurity.filters.JerseyAwareWebSecurityFilter;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.server.AbstractServerFactory;
@@ -121,9 +121,9 @@ public final class WebSecurityBundle implements ConfiguredBundle<WebSecurityConf
     }
 
     private static void applyWebSecurity(WebSecurityConfiguration derivedConfig, Environment env, String jerseyRoot) {
-        WebSecurityFilter filter = new WebSecurityFilter(derivedConfig, jerseyRoot);
+        JerseyAwareWebSecurityFilter filter = new JerseyAwareWebSecurityFilter(derivedConfig, jerseyRoot);
         env.servlets()
-                .addFilter("WebSecurityFilter", filter)
+                .addFilter("JerseyAwareWebSecurityFilter", filter)
                 .addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, ROOT_PATH);
     }
 

--- a/src/main/java/com/palantir/websecurity/filters/JerseyAwareWebSecurityFilter.java
+++ b/src/main/java/com/palantir/websecurity/filters/JerseyAwareWebSecurityFilter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.websecurity.filters;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.palantir.websecurity.WebSecurityConfiguration;
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A filter that injects the App Security headers using a {@link WebSecurityHeaderInjector} to all requests except for
+ * those on the {@link #jerseyRoot} path.
+ */
+public final class JerseyAwareWebSecurityFilter implements Filter {
+
+    private final WebSecurityHeaderInjector injector;
+    private final String jerseyRoot;
+
+    public JerseyAwareWebSecurityFilter(WebSecurityConfiguration config, String jerseyRoot) {
+        checkNotNull(config);
+        checkNotNull(jerseyRoot);
+
+        this.injector = new WebSecurityHeaderInjector(config);
+        this.jerseyRoot = cleanJerseyRoot(jerseyRoot);
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        // intentionally left blank
+    }
+
+    @Override
+    public void destroy() {
+        // intentionally left blank
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        checkNotNull(request);
+        checkNotNull(response);
+        checkNotNull(chain);
+
+        if (request instanceof HttpServletRequest && response instanceof HttpServletResponse) {
+            HttpServletRequest httpRequest = (HttpServletRequest) request;
+
+            if (!isJerseyRequest(httpRequest)) {
+                this.injector.injectHeaders(httpRequest, (HttpServletResponse) response);
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private boolean isJerseyRequest(HttpServletRequest request) {
+        String cleanedServletPath = cleanJerseyRoot(request.getServletPath().toLowerCase());
+        return this.jerseyRoot.equals(cleanedServletPath);
+    }
+
+    /**
+     * Cleans the Jersey root path to start with a slash and end without a star or slash.
+     */
+    private static String cleanJerseyRoot(String rawJerseyRoot) {
+        String cleaned = rawJerseyRoot;
+
+        if (cleaned.endsWith("*")) {
+            cleaned = cleaned.substring(0, cleaned.length() - 1);
+        }
+
+        if (cleaned.endsWith("/")) {
+            cleaned = cleaned.substring(0, cleaned.length() - 1);
+        }
+
+        if (!cleaned.startsWith("/")) {
+            cleaned = "/" + cleaned;
+        }
+
+        return cleaned;
+    }
+}

--- a/src/test/java/com/palantir/websecurity/filters/JerseyAwareWebSecurityFilterTests.java
+++ b/src/test/java/com/palantir/websecurity/filters/JerseyAwareWebSecurityFilterTests.java
@@ -18,9 +18,9 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
- * Tests for {@link WebSecurityFilter}.
+ * Tests for {@link JerseyAwareWebSecurityFilter}.
  */
-public final class WebSecurityFilterTests {
+public final class JerseyAwareWebSecurityFilterTests {
 
     private static final WebSecurityConfiguration DEFAULT_CONFIG = WebSecurityConfiguration.DEFAULT;
 
@@ -31,7 +31,7 @@ public final class WebSecurityFilterTests {
     public void testInjectInHttpServletRequests() throws IOException, ServletException {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/index.html");
 
-        WebSecurityFilter filter = new WebSecurityFilter(DEFAULT_CONFIG, "/jersey/root/*");
+        JerseyAwareWebSecurityFilter filter = new JerseyAwareWebSecurityFilter(DEFAULT_CONFIG, "/jersey/root/*");
         request.setPathInfo("/api");
 
         filter.doFilter(request, response, chain);
@@ -42,23 +42,23 @@ public final class WebSecurityFilterTests {
 
     @Test
     public void testNotInjectForJerseyPathWithStar() throws IOException, ServletException {
-        WebSecurityFilter filter = new WebSecurityFilter(DEFAULT_CONFIG, "/api/*");
+        JerseyAwareWebSecurityFilter filter = new JerseyAwareWebSecurityFilter(DEFAULT_CONFIG, "/api/*");
         assertNotInjecting(filter);
     }
 
     @Test
     public void testNotInjectForJerseyPathNoStar() throws IOException, ServletException {
-        WebSecurityFilter filter = new WebSecurityFilter(DEFAULT_CONFIG, "/api/");
+        JerseyAwareWebSecurityFilter filter = new JerseyAwareWebSecurityFilter(DEFAULT_CONFIG, "/api/");
         assertNotInjecting(filter);
     }
 
     @Test
     public void testNotInjectForJerseyPathNoSlash() throws IOException, ServletException {
-        WebSecurityFilter filter = new WebSecurityFilter(DEFAULT_CONFIG, "/api");
+        JerseyAwareWebSecurityFilter filter = new JerseyAwareWebSecurityFilter(DEFAULT_CONFIG, "/api");
         assertNotInjecting(filter);
     }
 
-    private void assertNotInjecting(WebSecurityFilter filter) throws IOException, ServletException {
+    private void assertNotInjecting(JerseyAwareWebSecurityFilter filter) throws IOException, ServletException {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/hello");
         // the servlet path is used to check if the request is for Jersey
         request.setServletPath("/api");


### PR DESCRIPTION
renamed the existing `WebSecurityFilter` to `JerseyAwareWebSecurityFilter` since it only adds the headers to non-jersey requests. added a new filter that always adds the headers called `WebSecurityFilter.

tests are still needed
