### PR TITLE
change immutable pattern

### DIFF
--- a/src/main/java/com/palantir/websecurity/AbstractCorsConfiguration.java
+++ b/src/main/java/com/palantir/websecurity/AbstractCorsConfiguration.java
@@ -4,7 +4,6 @@
 
 package com.palantir.websecurity;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import io.dropwizard.validation.ValidationMethod;
@@ -21,10 +20,8 @@ import org.immutables.value.Value;
  * passed in as an initial parameter.
  */
 @Value.Immutable
-@ImmutableStyles
-@JsonDeserialize(as = ImmutableCorsConfiguration.class)
 @SuppressWarnings("checkstyle:designforextension")
-public abstract class CorsConfiguration {
+abstract class AbstractCorsConfiguration {
 
     private static final String DISABLED_ORIGINS = "";
 
@@ -122,40 +119,5 @@ public abstract class CorsConfiguration {
         }
 
         return true;
-    }
-
-    /**
-     * Provides a configuration with default values.
-     */
-    public static final CorsConfiguration DEFAULT = CorsConfiguration.builder().build();
-
-    /**
-     * Provides a configuration that is disabled.
-     */
-    public static final CorsConfiguration DISABLED = CorsConfiguration.builder()
-            .allowedOrigins(DISABLED_ORIGINS)
-            .build();
-
-    // hides implementation details
-    public static Builder builder() {
-        return ImmutableCorsConfiguration.builder();
-    }
-
-    // hides implementation details
-    public interface Builder {
-
-        Builder allowCredentials(boolean allowCredentials);
-
-        Builder allowedHeaders(String allowedHeaders);
-
-        Builder allowedMethods(String allowedMethods);
-
-        Builder allowedOrigins(String allowedOrigins);
-
-        Builder exposedHeaders(String exposedHeaders);
-
-        Builder preflightMaxAge(long preflightMaxAge);
-
-        CorsConfiguration build();
     }
 }

--- a/src/main/java/com/palantir/websecurity/AbstractWebSecurityConfiguration.java
+++ b/src/main/java/com/palantir/websecurity/AbstractWebSecurityConfiguration.java
@@ -4,7 +4,6 @@
 
 package com.palantir.websecurity;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Optional;
 import org.immutables.value.Value.Immutable;
 
@@ -12,9 +11,7 @@ import org.immutables.value.Value.Immutable;
  * Root-level Configuration for the {@link WebSecurityBundle}.
  */
 @Immutable
-@ImmutableStyles
-@JsonDeserialize(as = ImmutableWebSecurityConfiguration.class)
-public abstract class WebSecurityConfiguration {
+abstract class AbstractWebSecurityConfiguration {
 
     public static final String TURN_OFF = "";
 
@@ -42,32 +39,4 @@ public abstract class WebSecurityConfiguration {
      * Configuration for CORS functionality.
      */
     public abstract Optional<CorsConfiguration> cors();
-
-    /**
-     * Provides a configuration with default values.
-     */
-    public static final WebSecurityConfiguration DEFAULT = WebSecurityConfiguration.builder().build();
-
-    // hides implementation details
-    public static Builder builder() {
-        return ImmutableWebSecurityConfiguration.builder();
-    }
-
-    // hides implementation details
-    public interface Builder {
-
-        Builder contentSecurityPolicy(String contentSecurityPolicy);
-
-        Builder contentTypeOptions(String contentTypeOptions);
-
-        Builder frameOptions(String frameOptions);
-
-        Builder xssProtection(String xssProtection);
-
-        Builder cors(CorsConfiguration corsConfiguration);
-
-        Builder from(WebSecurityConfiguration otherConfig);
-
-        WebSecurityConfiguration build();
-    }
 }

--- a/src/main/java/com/palantir/websecurity/ImmutableStyles.java
+++ b/src/main/java/com/palantir/websecurity/ImmutableStyles.java
@@ -4,6 +4,7 @@
 
 package com.palantir.websecurity;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 import org.immutables.value.Value.Style;
@@ -13,7 +14,9 @@ import org.immutables.value.Value.Style;
  */
 
 @Target({ElementType.PACKAGE, ElementType.TYPE})
+@JsonSerialize
 @Style(
-        visibility = Style.ImplementationVisibility.PACKAGE
+        typeImmutable = "*",
+        visibility = Style.ImplementationVisibility.PUBLIC
 )
 @interface ImmutableStyles {}

--- a/src/main/java/com/palantir/websecurity/package-info.java
+++ b/src/main/java/com/palantir/websecurity/package-info.java
@@ -1,0 +1,6 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+@com.palantir.websecurity.ImmutableStyles
+package com.palantir.websecurity;

--- a/src/test/java/com/palantir/websecurity/CorsConfigurationTests.java
+++ b/src/test/java/com/palantir/websecurity/CorsConfigurationTests.java
@@ -4,7 +4,6 @@
 
 package com.palantir.websecurity;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.Iterables;
@@ -21,11 +20,6 @@ import org.junit.Test;
 public final class CorsConfigurationTests {
 
     private static final Validator VALIDATOR = BaseValidator.newValidator();
-
-    @Test
-    public void testDisabled() {
-        assertFalse(CorsConfiguration.DISABLED.enabled());
-    }
 
     @Test
     public void testAllowedOrigins_allowStar() {

--- a/src/test/java/com/palantir/websecurity/WebSecurityBundleTests.java
+++ b/src/test/java/com/palantir/websecurity/WebSecurityBundleTests.java
@@ -28,6 +28,10 @@ import org.mockito.ArgumentCaptor;
  */
 public final class WebSecurityBundleTests {
 
+    private static final CorsConfiguration DISABLED = CorsConfiguration.builder()
+            .allowedOrigins("")
+            .build();
+
     private final WebSecurityConfigurable appConfig = mock(WebSecurityConfigurable.class);
     private final FilterRegistration.Dynamic dynamic = mock(FilterRegistration.Dynamic.class);
     private final Environment environment = mock(Environment.class, RETURNS_DEEP_STUBS);
@@ -35,7 +39,7 @@ public final class WebSecurityBundleTests {
     @Test
     public void testDefaultFiltersApplied() throws Exception {
         WebSecurityBundle bundle = new WebSecurityBundle();
-        WebSecurityConfiguration webSecurityConfig = WebSecurityConfiguration.DEFAULT;
+        WebSecurityConfiguration webSecurityConfig = WebSecurityConfiguration.builder().build();
 
         when(this.appConfig.getWebSecurityConfiguration()).thenReturn(webSecurityConfig);
 
@@ -62,7 +66,7 @@ public final class WebSecurityBundleTests {
     public void testFiltersNotAppliedWhenDisabled() throws Exception {
         WebSecurityBundle bundle = new WebSecurityBundle();
         WebSecurityConfiguration webSecurityConfig = WebSecurityConfiguration.builder()
-                .cors(CorsConfiguration.DISABLED)
+                .cors(DISABLED)
                 .build();
 
         when(this.appConfig.getWebSecurityConfiguration()).thenReturn(webSecurityConfig);
@@ -78,7 +82,7 @@ public final class WebSecurityBundleTests {
                 .cors(CorsConfiguration.builder().allowedOrigins("http://origin").build())
                 .build();
         WebSecurityConfiguration yamlConfig = WebSecurityConfiguration.builder()
-                .cors(CorsConfiguration.DISABLED)
+                .cors(DISABLED)
                 .build();
         WebSecurityBundle bundle = new WebSecurityBundle(appDefaultConfig);
 

--- a/src/test/java/com/palantir/websecurity/examples/Example.java
+++ b/src/test/java/com/palantir/websecurity/examples/Example.java
@@ -62,8 +62,9 @@ public final class Example {
         @JsonProperty("webSecurity")
         @NotNull
         @Valid
-        private final WebSecurityConfiguration webSecurity = WebSecurityConfiguration.DEFAULT;
+        private final WebSecurityConfiguration webSecurity = WebSecurityConfiguration.builder().build();
 
+        @Override
         public WebSecurityConfiguration getWebSecurityConfiguration() {
             return this.webSecurity;
         }

--- a/src/test/java/com/palantir/websecurity/filters/JerseyAwareWebSecurityFilterTests.java
+++ b/src/test/java/com/palantir/websecurity/filters/JerseyAwareWebSecurityFilterTests.java
@@ -22,7 +22,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
  */
 public final class JerseyAwareWebSecurityFilterTests {
 
-    private static final WebSecurityConfiguration DEFAULT_CONFIG = WebSecurityConfiguration.DEFAULT;
+    private static final WebSecurityConfiguration DEFAULT_CONFIG = WebSecurityConfiguration.builder().build();
 
     private final MockHttpServletResponse response = new MockHttpServletResponse();
     private final FilterChain chain = mock(FilterChain.class);

--- a/src/test/java/com/palantir/websecurity/filters/WebSecurityHeaderInjectorTests.java
+++ b/src/test/java/com/palantir/websecurity/filters/WebSecurityHeaderInjectorTests.java
@@ -44,7 +44,7 @@ public final class WebSecurityHeaderInjectorTests {
 
     @Test
     public void testHeadersReplacedNotAppended() {
-        WebSecurityConfiguration config = WebSecurityConfiguration.DEFAULT;
+        WebSecurityConfiguration config = WebSecurityConfiguration.builder().build();
         WebSecurityHeaderInjector injector = new WebSecurityHeaderInjector(config);
 
         request.addHeader(HttpHeaders.USER_AGENT, WebSecurityHeaderInjector.USER_AGENT_IE_10);


### PR DESCRIPTION
use generated classes instead of the abstract class.

The abstract classes are now package private and the generated classes are public

pros
- remove more boilerplate code, such as `JsonSerialize(as = Immutable*.class)` and extending builders
- only expose the generated classes vs both abstract class and generated class using the old pattern
- value classes are always `final`

cons
- readability via github, people won't be able find the files.
- ability to mock the classes. 
