### PR TITLE
Update web-security-bundle for dropwizard 1.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,4 +42,4 @@ dependencies {
 group 'com.palantir.websecurity'
 version gitVersion()
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   java:
-    version: openjdk7
+    version: openjdk8
   environment:
     TERM: dumb
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 baselineVersion=0.4.1
 
 # compile
-dropwizardVersion=0.9.2
+dropwizardVersion=1.0.0
 
 # testCompile
 junitVersion = 4.12

--- a/src/main/java/com/palantir/websecurity/WebSecurityBundle.java
+++ b/src/main/java/com/palantir/websecurity/WebSecurityBundle.java
@@ -16,6 +16,7 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import java.util.EnumSet;
 import java.util.Map;
+import java.util.Optional;
 import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
@@ -138,7 +139,10 @@ public final class WebSecurityBundle implements ConfiguredBundle<WebSecurityConf
             Configuration dwConfig = (Configuration) configuration;
             if (dwConfig.getServerFactory() instanceof AbstractServerFactory) {
                 AbstractServerFactory abstractServerFactory = (AbstractServerFactory) dwConfig.getServerFactory();
-                rootPath = abstractServerFactory.getJerseyRootPath();
+                Optional<String> optionalRootPath = abstractServerFactory.getJerseyRootPath();
+                if (optionalRootPath.isPresent()) {
+                    rootPath = optionalRootPath.get();
+                }
             }
         }
 

--- a/src/test/java/com/palantir/websecurity/examples/ExampleRestTests.java
+++ b/src/test/java/com/palantir/websecurity/examples/ExampleRestTests.java
@@ -12,6 +12,7 @@ import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
+import org.glassfish.jersey.client.ClientProperties;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -32,7 +33,10 @@ public final class ExampleRestTests {
 
     @BeforeClass
     public static void beforeClass() {
-        client = new JerseyClientBuilder(RULE.getEnvironment()).build("tests");
+        client = new JerseyClientBuilder(RULE.getEnvironment())
+                .withProperty(ClientProperties.CONNECT_TIMEOUT, 1000)
+                .withProperty(ClientProperties.READ_TIMEOUT, 1000)
+                .build("tests");
     }
 
     @Test

--- a/src/test/java/com/palantir/websecurity/examples/ExampleWebTests.java
+++ b/src/test/java/com/palantir/websecurity/examples/ExampleWebTests.java
@@ -13,6 +13,7 @@ import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
+import org.glassfish.jersey.client.ClientProperties;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -33,7 +34,10 @@ public final class ExampleWebTests {
 
     @BeforeClass
     public static void beforeClass() {
-        client = new JerseyClientBuilder(RULE.getEnvironment()).build("tests");
+        client = new JerseyClientBuilder(RULE.getEnvironment())
+                .withProperty(ClientProperties.CONNECT_TIMEOUT, 1000)
+                .withProperty(ClientProperties.READ_TIMEOUT, 1000)
+                .build("tests");
     }
 
     @Test


### PR DESCRIPTION
This version, like dropwizard 1.0.0, supports java 8+
